### PR TITLE
(maint) support ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository provides a control repo with a collection of task modules for
 getting started with Puppet tasks. The tasks in this module can be used both
 with `bolt task run` on the command line and in Puppet Plans. This repository
-also contains a few utility functions for use in plans.
+also contains a few utility functions for use in plans. 
 
 ## Installation and usage
 
@@ -48,38 +48,12 @@ for this. You can run the plan with
 bolt --modules $repo plan run minifact::info nodes=$nodes
 ```
 
-#### canary
-
-The `canary` module contains a plan for running a task on canary nodes and then continuing on all nodes if it succeeds.
-
-```
-bolt --modules $repo plan run canary::random nodes=$nodes task=install_puppet canary_size=3
-```
-
-#### aggregate
-
-The aggregate module contains two plans to run a task and aggregrate the results
-
-`aggregate::count`
-: This returns a hash that for each key in the results counts how many times each value occurs.
-
-`aggregate::nodes`
-: This returns a hash that for each key makes a list of nodes that have a given value.
-
-
-```
-bolt --modules $repo plan run aggregate::count nodes=$nodes task=install_puppet params=<must be passed as json>
-```
-
 ### Functions
 
 The following functions are available for use in your plans:
 
 | Function | Purpose |
 |------|---------|
-| `aggregate::count`(ExecutionResult $result) | This returns a hash that for each key in the results counts how many times each value occurs.
-| `aggregate::nodes`(ExecutionResult $result) | This returns a hash that for each key makes a list of nodes that have a given value.
-| `canary::merge`(ExecutionResult $first, ExecutionReuslt $secon) | Merge to execution results prefering nodes from the second.
 | `util::print(String $message)` | Print a message on the console |
 | `util::exit(Integer $exitcode = 0)` | Exit bolt immediately |
 | `util::error(String $message, Integer $exitcode = 1)` | Print the message and exit with the given exitcode |

--- a/site/install_puppet/tasks/init.sh
+++ b/site/install_puppet/tasks/init.sh
@@ -530,6 +530,7 @@ case $platform in
           "16.04") deb_codename="xenial";;
           "16.10") deb_codename="yakkety";;
           "17.04") deb_codename="zesty";;
+          "18.04") deb_codename="bionic";;
           "14.10") utopic;;
         esac
         filetype="deb"


### PR DESCRIPTION
Add ubuntu 18.04 debian codename to download puppet5 release.